### PR TITLE
Feature/ek version 7

### DIFF
--- a/kustomizations/bigbang/values.yaml
+++ b/kustomizations/bigbang/values.yaml
@@ -47,8 +47,12 @@ gatekeeper:
 # EFK -> PLG, see https://repo1.dso.mil/platform-one/big-bang/bigbang/-/blob/1.39.0/docs/guides/using-bigbang/efk-plg-logging-migration.md
 logging:
   enabled: true
+  git:
+    tag: "0.7.1-bb.0"
 eckoperator:
   enabled: true
+  git:
+    tag: "2.2.0-bb.0"
 fluentbit:
   enabled: true
 jaeger:

--- a/kustomizations/dataplane-ek/gitrepository.yaml
+++ b/kustomizations/dataplane-ek/gitrepository.yaml
@@ -7,6 +7,6 @@ spec:
   interval: 5m
   url: https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git
   ref:
-    tag: "0.12.1-bb.0"
+    tag: "0.7.1-bb.0"
   secretRef:
     name: private-git-server

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -41,15 +41,20 @@ components:
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git@41.5.0-bb.1
       - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git@0.11.3-bb.2
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.12.1-bb.0
+      - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.7.1-bb.0
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git@2.4.0-bb.0
+      - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git@2.2.0-bb.0
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git@0.20.9-bb.0
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/jaeger.git@2.36.0-bb.1
 
     images:
       - registry1.dso.mil/ironbank/big-bang/base:2.0.0
       - registry1.dso.mil/ironbank/big-bang/grafana/grafana-plugins:9.2.0
+      - registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:2.2.0
       - registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:2.4.0
+      - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:7.17.1
       - registry1.dso.mil/ironbank/elastic/elasticsearch/elasticsearch:8.4.3
+      - registry1.dso.mil/ironbank/elastic/kibana/kibana:7.17.1
       - registry1.dso.mil/ironbank/elastic/kibana/kibana:8.4.3
       - registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.19.5
       - registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.9.9
@@ -145,6 +150,7 @@ components:
     required: true
     repos:
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.12.1-bb.0
+      - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git@0.7.1-bb.0
     manifests:
       - name: dataplane-ek
         files:


### PR DESCRIPTION
Reverts to versions of `eck-operator` and `elasticsearch-kibana` charts running ES major version 7.

Leaving in the repos/images for version 8 (deployed on current versions of BB).